### PR TITLE
LICENSE is listed wrong

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "text formatting",
     "string formatting"
   ],
-  "license": "CC0-1.0",
+  "license": "Unlicense",
   "author": "Loz Jackson",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Update the package.json to correctly list the license used.